### PR TITLE
add support for Angular v20.2

### DIFF
--- a/src/patch-angular-shadowdom-renderer.js
+++ b/src/patch-angular-shadowdom-renderer.js
@@ -41,8 +41,8 @@ files.forEach(file => {
 class ShadowDomRenderer extends DefaultDomRenderer2 {
    hostEl;
     shadowRoot;
-    constructor(eventManager, hostEl, component, doc, ngZone, nonce, platformIsServer, tracingService) {
-        super(eventManager, doc, ngZone, platformIsServer, tracingService);
+    constructor(eventManager, hostEl, component, doc, ngZone, nonce, platformIsServer, tracingService, registry, maxAnimationTimeout) {
+        super(eventManager, doc, ngZone, platformIsServer, tracingService, registry, maxAnimationTimeout);
         this.hostEl = hostEl;
         this.shadowRoot = hostEl.attachShadow({ mode: 'open' });
         let styles = component.styles;


### PR DESCRIPTION
The latest version of Angular has some changes inside the file that we are patching which are not being reflected in the patched code.

The `shadowDomRenderer` now expects two new properties; `registry, maxAnimationTimeout`. When they aren't in the constructor this causes some issues